### PR TITLE
feat: update release workflow to include publishing step

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
 
+      - name: Publish
+        run: dotnet publish --configuration Release --output ./publish
+
       - name: Extract App Name and Version from .csproj
         id: extract_metadata
         shell: pwsh
@@ -35,6 +38,11 @@ jobs:
           echo "APP_NAME=$appName" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      - name: Create ZIP package
+        shell: pwsh
+        run: |
+          Compress-Archive -Path ./publish/* -DestinationPath ${{ env.APP_NAME }}-v${{ env.VERSION }}-win-x64.zip
+
       # Create a GitHub Release
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -43,5 +51,6 @@ jobs:
           name: ${{ env.APP_NAME }} v${{ env.VERSION }}
           draft: false
           prerelease: false
+          files: ${{ env.APP_NAME }}-v${{ env.VERSION }}-win-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MouseGuard.csproj
+++ b/MouseGuard.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <AppName>MouseGuard</AppName>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request introduces changes to automate the packaging and release process in the GitHub Actions workflow and updates the application version in the project file. The key updates include adding steps to publish the application, create a ZIP package, and attach it to the GitHub release, as well as incrementing the version number in the `.csproj` file.

### Workflow automation updates:
* [`.github/workflows/release-on-merge.yml`](diffhunk://#diff-014acb62cbe0b3a074e82cc7d47b4c76a9374b1846d450780f36a3e7432192fdR28-R30): Added a `Publish` step to build and publish the application output to a `./publish` directory.
* [`.github/workflows/release-on-merge.yml`](diffhunk://#diff-014acb62cbe0b3a074e82cc7d47b4c76a9374b1846d450780f36a3e7432192fdR41-R45): Added a `Create ZIP package` step to compress the published output into a versioned ZIP file.
* [`.github/workflows/release-on-merge.yml`](diffhunk://#diff-014acb62cbe0b3a074e82cc7d47b4c76a9374b1846d450780f36a3e7432192fdR54): Updated the `Create Release` step to include the generated ZIP file as an attachment in the GitHub release.
