### PR TITLE
attempt to reduce false positive in Windows Defender

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -26,7 +26,7 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Publish
-        run: dotnet publish --configuration Release --output ./publish
+        run: dotnet publish --configuration Release --runtime win-x64 --output ./publish
 
       - name: Extract App Name and Version from .csproj
         id: extract_metadata

--- a/MouseGuard.csproj
+++ b/MouseGuard.csproj
@@ -7,6 +7,10 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <AppName>MouseGuard</AppName>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request introduces changes to enhance the .NET application's publishing process and updates the application's version. The most significant changes include specifying the runtime for publishing, enabling single-file publishing, and incrementing the application version.

### Publishing process improvements:
* [`.github/workflows/release-on-merge.yml`](diffhunk://#diff-014acb62cbe0b3a074e82cc7d47b4c76a9374b1846d450780f36a3e7432192fdL29-R29): Updated the `dotnet publish` command to specify the `win-x64` runtime for publishing.
* [`MouseGuard.csproj`](diffhunk://#diff-34b5dce5921827cc23ace165678c4c5ace8e6295786c56e5a97893c6c47dfe6fR10-R13): Added properties to enable single-file publishing (`<PublishSingleFile>true</PublishSingleFile>`), set the application as not self-contained (`<SelfContained>false</SelfContained>`), specify the runtime identifier as `win-x64`, and include native libraries for self-extraction.

### Version update:
* [`MouseGuard.csproj`](diffhunk://#diff-34b5dce5921827cc23ace165678c4c5ace8e6295786c56e5a97893c6c47dfe6fL26-R30): Incremented the application version from `1.0.7` to `1.0.8`.…p version to 1.0.8